### PR TITLE
API 28 이하: 영상 수정한 날짜 내림차순으로 정렬되게 수정

### DIFF
--- a/app/src/main/java/com/boostcamp/dailyfilm/data/selectvideo/GalleryPagingSource.kt
+++ b/app/src/main/java/com/boostcamp/dailyfilm/data/selectvideo/GalleryPagingSource.kt
@@ -65,7 +65,7 @@ class GalleryPagingSource @Inject constructor(
 
         val query = if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {
             val sortOrder =
-                "${MediaStore.Video.Media.DISPLAY_NAME} ASC LIMIT $PAGING_SIZE OFFSET $start"
+                "${MediaStore.Video.Media.DATE_MODIFIED} DESC LIMIT $PAGING_SIZE OFFSET $start"
 
             contentResolver.query(
                 collection,


### PR DESCRIPTION
# PR 내용

+ 커스텀 갤러리에서 API 28 이하는 정렬하지 않는 누락 코드 수정 (가져오는 비디오 URI를 수정한 날짜대로 정렬)

Resolve: #62 