### PR TITLE
영상 비동기 압축

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -98,7 +98,7 @@ dependencies {
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
 
     // ffmpeg
-    implementation 'com.github.TTC1018:android-video-trimmer:0.1.2-async'
+    implementation 'com.github.TTC1018:android-video-trimmer:0.1.3-async'
     implementation 'com.arthenica:mobile-ffmpeg-min-gpl:4.4'
 
     // lottie

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -98,7 +98,8 @@ dependencies {
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
 
     // ffmpeg
-    implementation 'com.github.TTC1018:android-video-trimmer:0.1.2'
+    implementation 'com.github.TTC1018:android-video-trimmer:0.1.2-async'
+    implementation 'com.arthenica:mobile-ffmpeg-min-gpl:4.4'
 
     // lottie
     implementation 'com.airbnb.android:lottie:5.0.2'

--- a/app/src/main/java/com/boostcamp/dailyfilm/presentation/trimvideo/TrimVideoActivity.kt
+++ b/app/src/main/java/com/boostcamp/dailyfilm/presentation/trimvideo/TrimVideoActivity.kt
@@ -32,9 +32,10 @@ class TrimVideoActivity : BaseActivity<ActivityTrimViedoBinding>(R.layout.activi
     private val startForResult: ActivityResultLauncher<Intent> =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
             if (result.resultCode == Activity.RESULT_OK && result.data != null) {
+                val startTime = TrimVideo.getTrimmedStartMilli(result.data)
                 val uri: Uri = Uri.parse(TrimVideo.getTrimmedVideoPath(result.data))
                 val uriString = Uri.parse("file://$uri")
-                viewModel.moveToUpload(uriString)
+                viewModel.moveToUpload(uriString, startTime)
             } else {
                 viewModel.moveToSelectVideo()
             }
@@ -57,7 +58,7 @@ class TrimVideoActivity : BaseActivity<ActivityTrimViedoBinding>(R.layout.activi
                             openTrimVideo(result)
                         }
                         is TrimVideoEvent.NextButtonResult -> {
-                            moveToUpload(result.dateAndVideoModelItem)
+                            moveToUpload(result.dateAndVideoModelItem, result.startTime)
 
                         }
                         is TrimVideoEvent.BackButtonResult -> {
@@ -93,7 +94,7 @@ class TrimVideoActivity : BaseActivity<ActivityTrimViedoBinding>(R.layout.activi
             .start(this@TrimVideoActivity, event.startForResult)
     }
 
-    private fun moveToUpload(trimAndVideoModel: DateAndVideoModel) {
+    private fun moveToUpload(trimAndVideoModel: DateAndVideoModel, startTime: Long) {
         startActivity(
             Intent(this, UploadFilmActivity::class.java).apply {
                 putExtra(
@@ -101,6 +102,7 @@ class TrimVideoActivity : BaseActivity<ActivityTrimViedoBinding>(R.layout.activi
                     trimAndVideoModel
                 )
                 putExtra(KEY_INFO_ITEM, viewModel.infoItem)
+                putExtra(KEY_START_TIME, startTime)
             }
         )
         finish()
@@ -121,5 +123,6 @@ class TrimVideoActivity : BaseActivity<ActivityTrimViedoBinding>(R.layout.activi
     companion object {
         const val KEY_INFO_ITEM = "beforeItem"
         const val KEY_DATE_MODEL = "date_model"
+        const val KEY_START_TIME = "start_time"
     }
 }

--- a/app/src/main/java/com/boostcamp/dailyfilm/presentation/trimvideo/TrimVideoViewModel.kt
+++ b/app/src/main/java/com/boostcamp/dailyfilm/presentation/trimvideo/TrimVideoViewModel.kt
@@ -38,8 +38,8 @@ class TrimVideoViewModel @Inject constructor(
         event(TrimVideoEvent.BackButtonResult(infoItem!!.getDateModel()))
     }
 
-    fun moveToUpload(uriString: Uri) {
-        event(TrimVideoEvent.NextButtonResult(DateAndVideoModel(uriString, infoItem!!.uploadDate)))
+    fun moveToUpload(uriString: Uri, startTime: Long) {
+        event(TrimVideoEvent.NextButtonResult(DateAndVideoModel(uriString, infoItem!!.uploadDate), startTime))
     }
 
     fun openTrimActivity(startForResult: ActivityResultLauncher<Intent>,videoWidthAndHeight:IntArray) {
@@ -67,7 +67,7 @@ class TrimVideoViewModel @Inject constructor(
 }
 
 sealed class TrimVideoEvent {
-    data class NextButtonResult(val dateAndVideoModelItem: DateAndVideoModel) : TrimVideoEvent()
+    data class NextButtonResult(val dateAndVideoModelItem: DateAndVideoModel, val startTime: Long) : TrimVideoEvent()
     data class BackButtonResult(val dateModel: DateModel) : TrimVideoEvent()
     data class InitOpenTrimVideo(val dateModel: DateAndVideoModel) :TrimVideoEvent()
     data class OpenTrimVideoResult(

--- a/app/src/main/java/com/boostcamp/dailyfilm/presentation/uploadfilm/UploadFilmBindingAdapter.kt
+++ b/app/src/main/java/com/boostcamp/dailyfilm/presentation/uploadfilm/UploadFilmBindingAdapter.kt
@@ -1,12 +1,22 @@
 package com.boostcamp.dailyfilm.presentation.uploadfilm
 
 import android.animation.ValueAnimator
+import android.net.Uri
+import android.util.Log
 import android.widget.EditText
 import androidx.databinding.BindingAdapter
 import com.airbnb.lottie.LottieAnimationView
+import com.google.android.exoplayer2.ExoPlayer
+import com.google.android.exoplayer2.MediaItem
+import com.google.android.exoplayer2.Player
+import com.google.android.exoplayer2.ui.StyledPlayerView
 
 @BindingAdapter(value = ["updateAnimation", "inputText", "showKeyboard"], requireAll = false)
-fun LottieAnimationView.updateAnimation(isWriting: Boolean, text: EditText, activity: UploadFilmActivity) {
+fun LottieAnimationView.updateAnimation(
+    isWriting: Boolean,
+    text: EditText,
+    activity: UploadFilmActivity
+) {
     lateinit var animator: ValueAnimator
 
     when (isWriting) {
@@ -30,4 +40,24 @@ fun LottieAnimationView.updateAnimation(isWriting: Boolean, text: EditText, acti
         progress = it.animatedValue as Float
     }
     animator.start()
+}
+
+@BindingAdapter(value = ["willBePlayed", "compressProgress"], requireAll = false)
+fun StyledPlayerView.playVideoWhenReady(uri: Uri?, progress: Int) {
+    if (player == null) {
+        player = ExoPlayer.Builder(context).build().apply {
+            volume = 0.5f
+            playWhenReady = true
+            repeatMode = Player.REPEAT_MODE_ONE
+        }
+    }
+
+    if (progress == 100){
+        uri?.let { videoUri ->
+            val mediaItem = MediaItem.fromUri(videoUri)
+            player?.setMediaItem(mediaItem)
+            player?.prepare()
+            player?.play()
+        }
+    }
 }

--- a/app/src/main/java/com/boostcamp/dailyfilm/presentation/uploadfilm/UploadFilmBindingAdapter.kt
+++ b/app/src/main/java/com/boostcamp/dailyfilm/presentation/uploadfilm/UploadFilmBindingAdapter.kt
@@ -10,6 +10,7 @@ import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.Player
 import com.google.android.exoplayer2.ui.StyledPlayerView
+import kotlinx.coroutines.*
 
 @BindingAdapter(value = ["updateAnimation", "inputText", "showKeyboard"], requireAll = false)
 fun LottieAnimationView.updateAnimation(
@@ -42,22 +43,29 @@ fun LottieAnimationView.updateAnimation(
     animator.start()
 }
 
-@BindingAdapter(value = ["willBePlayed", "compressProgress"], requireAll = false)
-fun StyledPlayerView.playVideoWhenReady(uri: Uri?, progress: Int) {
+@BindingAdapter(value = ["originVideo", "videoStartTime"], requireAll = false)
+fun StyledPlayerView.playVideoAt(uri: Uri?, startTime: Long) {
     if (player == null) {
         player = ExoPlayer.Builder(context).build().apply {
             volume = 0.5f
-            playWhenReady = true
             repeatMode = Player.REPEAT_MODE_ONE
         }
     }
 
-    if (progress == 100){
-        uri?.let { videoUri ->
-            val mediaItem = MediaItem.fromUri(videoUri)
-            player?.setMediaItem(mediaItem)
-            player?.prepare()
-            player?.play()
+    uri?.let {
+        val mediaItem = MediaItem.fromUri(it)
+        player?.setMediaItem(mediaItem)
+        player?.prepare()
+        player?.seekTo(startTime) // 시작 지점 정하기
+        player?.play()
+
+        CoroutineScope(Dispatchers.Main).launch {
+            while (true){
+                delay(10000) // 10초 만큼 진행하고
+                player?.seekTo(startTime) // 다시 시작지점으로
+                if (player == null) // 메모리 누수 방지
+                    break
+            }
         }
     }
 }

--- a/app/src/main/java/com/boostcamp/dailyfilm/presentation/uploadfilm/UploadFilmViewModel.kt
+++ b/app/src/main/java/com/boostcamp/dailyfilm/presentation/uploadfilm/UploadFilmViewModel.kt
@@ -18,6 +18,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.math.ceil
 
 @HiltViewModel
 class UploadFilmViewModel @Inject constructor(
@@ -26,6 +27,7 @@ class UploadFilmViewModel @Inject constructor(
 ) : ViewModel() {
     val infoItem = savedStateHandle.get<DateAndVideoModel>(SelectVideoActivity.DATE_VIDEO_ITEM)
     val beforeItem = savedStateHandle.get<DateAndVideoModel>(KEY_INFO_ITEM)
+    val startTime = savedStateHandle.get<Long>(KEY_START_TIME) ?: 0L
     private val _uploadResult = MutableSharedFlow<Uri?>()
     val uploadResult: SharedFlow<Uri?> get() = _uploadResult
 
@@ -59,7 +61,7 @@ class UploadFilmViewModel @Inject constructor(
     private fun calcProgress() {
         Config.resetStatistics()
         Config.enableStatisticsCallback {
-            val percentage = (it.time.toFloat() / 10000 * 100).toInt()
+            val percentage = ceil(it.time.toFloat() / 10000 * 100).toInt()
             _compressProgress.postValue(percentage)
         }
     }
@@ -169,5 +171,6 @@ class UploadFilmViewModel @Inject constructor(
 
     companion object {
         const val KEY_INFO_ITEM = "beforeItem"
+        const val KEY_START_TIME = "start_time"
     }
 }

--- a/app/src/main/java/com/boostcamp/dailyfilm/presentation/uploadfilm/UploadFilmViewModel.kt
+++ b/app/src/main/java/com/boostcamp/dailyfilm/presentation/uploadfilm/UploadFilmViewModel.kt
@@ -4,7 +4,9 @@ package com.boostcamp.dailyfilm.presentation.uploadfilm
 import android.net.Uri
 import android.text.SpannableString
 import android.text.Spanned
+import android.util.Log
 import androidx.lifecycle.*
+import com.arthenica.mobileffmpeg.Config
 import com.boostcamp.dailyfilm.data.model.DailyFilmItem
 import com.boostcamp.dailyfilm.data.model.Result
 import com.boostcamp.dailyfilm.data.uploadfilm.UploadFilmRepository
@@ -47,12 +49,36 @@ class UploadFilmViewModel @Inject constructor(
     private val _clickSound = MutableStateFlow(true)
     val clickSound = _clickSound.asStateFlow()
 
+    private val _compressProgress = MutableLiveData(0)
+    val compressProgress: LiveData<Int> get() = _compressProgress
+
+    init {
+        calcProgress()
+    }
+
+    private fun calcProgress() {
+        Config.resetStatistics()
+        Config.enableStatisticsCallback {
+            val percentage = (it.time.toFloat() / 10000 * 100).toInt()
+            _compressProgress.postValue(percentage)
+        }
+    }
+
     fun uploadVideo() {
         val text = textContent.value ?: ""
-        if (text.isEmpty()) {
-            _uiState.value = UiState.Failure(Throwable("영상에 맞는 문구를 입력해주세요."))
-            return
+        val progress = _compressProgress.value ?: 0
+
+        when {
+            text.isEmpty() -> {
+                _uiState.value = UiState.Failure(Throwable("영상에 맞는 문구를 입력해주세요."))
+                return
+            }
+            progress < 100 -> {
+                _uiState.value = UiState.Failure(Throwable("영상 처리중입니다. 잠시만 기다려주세요."))
+                return
+            }
         }
+
         infoItem?.let { item ->
             _uiState.value = UiState.Loading
             viewModelScope.launch {

--- a/app/src/main/res/layout/activity_upload_film.xml
+++ b/app/src/main/res/layout/activity_upload_film.xml
@@ -75,9 +75,8 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:willBePlayed="@{viewModel.infoItem.uri}"
-            app:compressProgress="@{viewModel.compressProgress}"
-            app:playVideo="@{viewModel.infoItem.uri}"
+            app:originVideo="@{viewModel.beforeItem.uri}"
+            app:videoStartTime="@{viewModel.startTime}"
             app:resize_mode="zoom"
             app:use_controller="false" />
 

--- a/app/src/main/res/layout/activity_upload_film.xml
+++ b/app/src/main/res/layout/activity_upload_film.xml
@@ -5,6 +5,8 @@
 
     <data>
 
+        <import type="android.view.View" />
+
         <variable
             name="activity"
             type="com.boostcamp.dailyfilm.presentation.uploadfilm.UploadFilmActivity" />
@@ -73,6 +75,8 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
+            app:willBePlayed="@{viewModel.infoItem.uri}"
+            app:compressProgress="@{viewModel.compressProgress}"
             app:playVideo="@{viewModel.infoItem.uri}"
             app:resize_mode="zoom"
             app:use_controller="false" />
@@ -134,6 +138,21 @@
             android:textColor="@color/white"
             android:textSize="22sp"
             app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/lottieAnimationView" />
+
+        <ProgressBar
+            android:id="@+id/pbar_compress"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="32dp"
+            android:layout_marginEnd="32dp"
+            android:progressTint="@color/white"
+            android:max="100"
+            android:progress="@{viewModel.compressProgress}"
+            android:visibility="@{viewModel.compressProgress &lt; 100 ? View.VISIBLE : View.GONE}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/lottieAnimationView" />


### PR DESCRIPTION
# PR 내용
+ 영상 선택시 바로 내용 작성 화면으로 넘어 가도록 압축 비동기 처리
+ 압축 경과율 UI에 출력
+ 압축 영상 시작 지점을 활용하여 원본 영상으로 미리보기 재생

### 압축 라이브러리 수정 사항
+ `FFmpeg.executeAsync`로 비동기 압축 및 즉각적으로 결과물 URI 리턴

Resolve: #101